### PR TITLE
Extended example with ZipkinSpanCollector per issue #4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
         <version>${brave.version}</version>
     </dependency>
     <dependency>
+        <groupId>com.github.kristofa</groupId>
+        <artifactId>brave-zipkin-spancollector</artifactId>
+        <version>${brave.version}</version>
+    </dependency>
+    <dependency>
     	<groupId>org.jboss.resteasy</groupId>
 	    <artifactId>resteasy-spring</artifactId>
 	    <version>${resteasy.version}</version>

--- a/src/main/java/com/github/kristofa/brave/resteasyexample/SpanCollectorConfiguration.java
+++ b/src/main/java/com/github/kristofa/brave/resteasyexample/SpanCollectorConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Scope;
 
 import com.github.kristofa.brave.LoggingSpanCollector;
 import com.github.kristofa.brave.SpanCollector;
+import com.github.kristofa.brave.zipkin.ZipkinSpanCollector;
 
 /**
  * {@link SpanCollector} spring dependency injection configuration.
@@ -21,5 +22,6 @@ public class SpanCollectorConfiguration {
 
         // For development purposes we use the logging span collector.
         return new LoggingSpanCollector();
+        // return new ZipkinSpanCollector("localhost", 9410);
     }
 }


### PR DESCRIPTION
Added dependency and code to make use of Zipkin server (deployed on localhost) vs logging spans into console. This logic is not enabled by default. To enable it uncomment [SpanCollectorConfiguration:25](https://github.com/kristofa/brave-resteasy-example/compare/master...mkostin:new/zipkin-span-collector-4#diff-7a7433fde50fe222a5d71d8bf7df2914R25) line and comment  `LoggingSpanCollector` instead.

Closes #4 
