### PR TITLE
Added package name to line 45

### DIFF
--- a/src/main/java/brave/webmvc/WebTracingConfiguration.java
+++ b/src/main/java/brave/webmvc/WebTracingConfiguration.java
@@ -42,7 +42,7 @@ public class WebTracingConfiguration extends WebMvcConfigurerAdapter {
   @Bean Reporter<Span> reporter() {
     return new LoggingReporter();
     // uncomment to actually send to zipkin!
-    //return AsyncReporter.builder(sender()).build();
+    //return zipkin.reporter.AsyncReporter.builder(sender()).build();
   }
 
   @Bean Brave brave() {


### PR DESCRIPTION
When you uncomment following line, you also have to add an import statement. 

```
  @Bean Reporter<Span> reporter() {
    // return new LoggingReporter();
    // uncomment to actually send to zipkin!
    // return AsyncReporter.builder(sender()).build();
  }
```

To realize that you have to add an import statement, you need to import the project into a IDE. To prevent importing, I added package name.