### PR TITLE
Shows how to trace Apache HttpClient requests

### DIFF
--- a/webmvc25/pom.xml
+++ b/webmvc25/pom.xml
@@ -45,17 +45,18 @@
       <version>${spring.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.zipkin.brave</groupId>
-      <artifactId>brave-instrumentation-spring-webmvc</artifactId>
-    </dependency>
-
-    <!-- Adds HttpClient support for calling the backend -->
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <!-- comment here if you can't use 4.4+ https://github.com/openzipkin/brave/issues/431 -->
       <version>4.4.1</version>
     </dependency>
+
+    <!-- Adds the MVC class and method names to server spans -->
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-instrumentation-spring-webmvc</artifactId>
+    </dependency>
+    <!-- Instruments the underlying HttpClient requests that call the backend -->
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-instrumentation-httpclient</artifactId>

--- a/webmvc3/pom.xml
+++ b/webmvc3/pom.xml
@@ -45,19 +45,26 @@
       <version>${spring.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.zipkin.brave</groupId>
-      <artifactId>brave-instrumentation-spring-webmvc</artifactId>
-    </dependency>
-
-    <!-- Adds RestTemplate support for calling the backend -->
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
       <version>${spring.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <!-- comment here if you can't use 4.4+ https://github.com/openzipkin/brave/issues/431 -->
+      <version>4.4.1</version>
+    </dependency>
+
+    <!-- Adds the MVC class and method names to server spans -->
+    <dependency>
       <groupId>io.zipkin.brave</groupId>
-      <artifactId>brave-instrumentation-spring-web</artifactId>
+      <artifactId>brave-instrumentation-spring-webmvc</artifactId>
+    </dependency>
+    <!-- Instruments the underlying HttpClient requests that call the backend -->
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-instrumentation-httpclient</artifactId>
     </dependency>
 
     <!-- Integrates so you can use log patterns like %X{traceId}/%X{spanId} -->

--- a/webmvc3/src/main/webapp/WEB-INF/spring-webmvc-servlet.xml
+++ b/webmvc3/src/main/webapp/WEB-INF/spring-webmvc-servlet.xml
@@ -10,12 +10,19 @@
         http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
+  <bean id="httpClientBuilder" class="brave.httpclient.TracingHttpClientBuilder"
+      factory-method="create">
+    <constructor-arg ref="httpTracing"/>
+  </bean>
+
+  <bean id="httpClient" factory-bean="httpClientBuilder" factory-method="build"/>
+
   <bean id="restTemplate" class="org.springframework.web.client.RestTemplate">
-    <property name="interceptors">
-      <list>
-        <bean class="brave.spring.web.TracingClientHttpRequestInterceptor" />
-      </list>
-    </property>
+    <constructor-arg>
+      <bean class="org.springframework.http.client.HttpComponentsClientHttpRequestFactory">
+        <constructor-arg ref="httpClient"/>
+      </bean>
+    </constructor-arg>
   </bean>
 
   <mvc:interceptors>

--- a/webmvc4-boot/pom.xml
+++ b/webmvc4-boot/pom.xml
@@ -45,12 +45,19 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+
+    <!-- Adds the MVC class and method names to server spans -->
+    <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-instrumentation-spring-webmvc</artifactId>
     </dependency>
+    <!-- Instruments the underlying HttpClient requests that call the backend -->
     <dependency>
       <groupId>io.zipkin.brave</groupId>
-      <artifactId>brave-instrumentation-spring-web</artifactId>
+      <artifactId>brave-instrumentation-httpclient</artifactId>
     </dependency>
 
     <!-- Integrates so you can use log patterns like %X{traceId}/%X{spanId} -->

--- a/webmvc4-boot/src/main/java/brave/webmvc/Frontend.java
+++ b/webmvc4-boot/src/main/java/brave/webmvc/Frontend.java
@@ -3,7 +3,7 @@ package brave.webmvc;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Bean;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,14 +14,14 @@ import org.springframework.web.client.RestTemplate;
 @CrossOrigin // So that javascript can be hosted elsewhere
 public class Frontend {
 
-  @Autowired RestTemplate restTemplate;
+  final RestTemplate restTemplate;
+
+  @Autowired Frontend(RestTemplateBuilder restTemplateBuilder) {
+    this.restTemplate = restTemplateBuilder.build();
+  }
 
   @RequestMapping("/") public String callBackend() {
     return restTemplate.getForObject("http://localhost:9000/api", String.class);
-  }
-
-  @Bean RestTemplate restTemplate() {
-    return new RestTemplate();
   }
 
   public static void main(String[] args) {

--- a/webmvc4-boot/src/main/java/brave/webmvc/TracingConfiguration.java
+++ b/webmvc4-boot/src/main/java/brave/webmvc/TracingConfiguration.java
@@ -3,23 +3,21 @@ package brave.webmvc;
 import brave.Tracing;
 import brave.context.slf4j.MDCScopeDecorator;
 import brave.http.HttpTracing;
+import brave.httpclient.TracingHttpClientBuilder;
 import brave.propagation.B3Propagation;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.servlet.TracingFilter;
-import brave.spring.web.TracingClientHttpRequestInterceptor;
 import brave.spring.webmvc.SpanCustomizingAsyncHandlerInterceptor;
-import java.util.ArrayList;
-import java.util.List;
 import javax.servlet.Filter;
-import org.springframework.beans.factory.BeanFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.web.client.RestTemplateCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
@@ -63,35 +61,18 @@ public class TracingConfiguration extends WebMvcConfigurerAdapter {
     return HttpTracing.create(tracing);
   }
 
-  /** Creates client spans for http requests */
-  // We are using a BPP as the Frontend supplies a RestTemplate bean prior to this configuration
-  @Bean BeanPostProcessor connectionFactoryDecorator(final BeanFactory beanFactory) {
-    return new BeanPostProcessor() {
-      @Override public Object postProcessBeforeInitialization(Object bean, String beanName) {
-        return bean;
-      }
-
-      @Override public Object postProcessAfterInitialization(Object bean, String beanName) {
-        if (!(bean instanceof RestTemplate)) return bean;
-
-        RestTemplate restTemplate = (RestTemplate) bean;
-        List<ClientHttpRequestInterceptor> interceptors =
-            new ArrayList<>(restTemplate.getInterceptors());
-        interceptors.add(0, getTracingInterceptor());
-        restTemplate.setInterceptors(interceptors);
-        return bean;
-      }
-
-      // Lazy lookup so that the BPP doesn't end up needing to proxy anything.
-      ClientHttpRequestInterceptor getTracingInterceptor() {
-        return TracingClientHttpRequestInterceptor.create(beanFactory.getBean(HttpTracing.class));
-      }
-    };
-  }
-
   /** Creates server spans for http requests */
   @Bean Filter tracingFilter(HttpTracing httpTracing) {
     return TracingFilter.create(httpTracing);
+  }
+
+  @Bean RestTemplateCustomizer useTracedHttpClient(HttpTracing httpTracing) {
+    final CloseableHttpClient httpClient = TracingHttpClientBuilder.create(httpTracing).build();
+    return new RestTemplateCustomizer() {
+      @Override public void customize(RestTemplate restTemplate) {
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory(httpClient));
+      }
+    };
   }
 
   @Autowired SpanCustomizingAsyncHandlerInterceptor webMvcTracingCustomizer;

--- a/webmvc4-boot/src/main/resources/application.properties
+++ b/webmvc4-boot/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # spring.application.name and server.port are set in the main methods,
 # so not done here
-logging.level.org.springframework.web=DEBUG
+logging.level.root=INFO
 # Adds trace and span IDs to logs (when a trace is in progress)
-logging.pattern.level=%d{ABSOLUTE} [%X{traceId}/%X{spanId}] %-5p [%t] %C{2} - %m%n
+logging.pattern.level=[%X{traceId}/%X{spanId}] %-5p [%t] %C{2} - %m%n

--- a/webmvc4/pom.xml
+++ b/webmvc4/pom.xml
@@ -16,7 +16,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
 
-    <spring.version>4.3.13.RELEASE</spring.version>
+    <spring.version>4.3.20.RELEASE</spring.version>
     <log4j.version>2.11.1</log4j.version>
     <brave.version>5.4.3</brave.version>
   </properties>
@@ -46,19 +46,25 @@
       <version>${spring.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.zipkin.brave</groupId>
-      <artifactId>brave-instrumentation-spring-webmvc</artifactId>
-    </dependency>
-
-    <!-- Adds RestTemplate support for calling the backend -->
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
       <version>${spring.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.6</version>
+    </dependency>
+
+    <!-- Adds the MVC class and method names to server spans -->
+    <dependency>
       <groupId>io.zipkin.brave</groupId>
-      <artifactId>brave-instrumentation-spring-web</artifactId>
+      <artifactId>brave-instrumentation-spring-webmvc</artifactId>
+    </dependency>
+    <!-- Instruments the underlying HttpClient requests that call the backend -->
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-instrumentation-httpclient</artifactId>
     </dependency>
 
     <!-- Integrates so you can use log patterns like %X{traceId}/%X{spanId} -->

--- a/webmvc4/src/main/java/brave/webmvc/AppConfiguration.java
+++ b/webmvc4/src/main/java/brave/webmvc/AppConfiguration.java
@@ -1,13 +1,22 @@
 package brave.webmvc;
 
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 /** The application is simple, it only uses Web MVC and a {@linkplain RestTemplate}. */
 @EnableWebMvc
 public class AppConfiguration {
+  @Autowired(required = false)
+  HttpClient httpClient;
+
   @Bean RestTemplate restTemplate() {
-    return new RestTemplate();
+    HttpClient httpClient = this.httpClient;
+    if (httpClient == null) httpClient = HttpClients.createDefault();
+    return new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));
   }
 }


### PR DESCRIPTION
This changes the example to use Apache `HttpClient` under the `RestTemplate` to make the call from the frontend to the backend.

Doing this as it is routinely asked about in support

https://github.com/openzipkin/brave/tree/master/instrumentation/httpclient