### PR TITLE
Adds Bean declaration for SpanCustomizer

### DIFF
--- a/webmvc25/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/webmvc25/src/main/webapp/WEB-INF/applicationContext.xml
@@ -13,6 +13,7 @@
   <!-- allows us to read the service name from spring config -->
   <context:property-placeholder/>
 
+  <!-- Controls aspects of tracing such as the service name that shows up in the UI -->
   <bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
     <property name="localServiceName" value="${zipkin.service}"/>
     <property name="spanReporter">
@@ -49,6 +50,12 @@
     </property>
   </bean>
 
+  <!-- Allows someone to add tags to a span if a trace is in progress, via SpanCustomizer -->
+  <bean id="spanCustomizer" class="brave.CurrentSpanCustomizer" factory-method="create">
+    <constructor-arg index="0" ref="tracing"/>
+  </bean>
+
+  <!-- Decides how to name and tag spans. By default they are named the same as the http method. -->
   <bean id="httpTracing" class="brave.spring.beans.HttpTracingFactoryBean">
     <property name="tracing" ref="tracing"/>
   </bean>

--- a/webmvc3/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/webmvc3/src/main/webapp/WEB-INF/applicationContext.xml
@@ -17,6 +17,7 @@
   <!-- allows us to read the service name from spring config -->
   <context:property-placeholder/>
 
+  <!-- Controls aspects of tracing such as the service name that shows up in the UI -->
   <bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
     <property name="localServiceName" value="${zipkin.service:brave-webmvc-example}"/>
     <property name="spanReporter">
@@ -48,6 +49,12 @@
     </property>
   </bean>
 
+  <!-- Allows someone to add tags to a span if a trace is in progress, via SpanCustomizer -->
+  <bean id="spanCustomizer" class="brave.CurrentSpanCustomizer" factory-method="create">
+    <constructor-arg index="0" ref="tracing"/>
+  </bean>
+
+  <!-- Decides how to name and tag spans. By default they are named the same as the http method. -->
   <bean id="httpTracing" class="brave.spring.beans.HttpTracingFactoryBean">
     <property name="tracing" ref="tracing"/>
   </bean>

--- a/webmvc4-boot/src/main/java/brave/webmvc/TracingConfiguration.java
+++ b/webmvc4-boot/src/main/java/brave/webmvc/TracingConfiguration.java
@@ -1,5 +1,7 @@
 package brave.webmvc;
 
+import brave.CurrentSpanCustomizer;
+import brave.SpanCustomizer;
 import brave.Tracing;
 import brave.context.slf4j.MDCScopeDecorator;
 import brave.http.HttpTracing;
@@ -44,7 +46,7 @@ public class TracingConfiguration extends WebMvcConfigurerAdapter {
     return AsyncReporter.create(sender());
   }
 
-  /** Controls aspects of tracing such as the name that shows up in the UI */
+  /** Controls aspects of tracing such as the service name that shows up in the UI */
   @Bean Tracing tracing(@Value("${spring.application.name}") String serviceName) {
     return Tracing.newBuilder()
         .localServiceName(serviceName)
@@ -56,7 +58,12 @@ public class TracingConfiguration extends WebMvcConfigurerAdapter {
         .spanReporter(spanReporter()).build();
   }
 
-  /** decides how to name and tag spans. By default they are named the same as the http method. */
+  /** Allows someone to add tags to a span if a trace is in progress */
+  @Bean SpanCustomizer spanCustomizer(Tracing tracing) {
+    return CurrentSpanCustomizer.create(tracing);
+  }
+
+  /** Decides how to name and tag spans. By default they are named the same as the http method */
   @Bean HttpTracing httpTracing(Tracing tracing) {
     return HttpTracing.create(tracing);
   }

--- a/webmvc4/src/main/java/brave/webmvc/TracingConfiguration.java
+++ b/webmvc4/src/main/java/brave/webmvc/TracingConfiguration.java
@@ -1,5 +1,7 @@
 package brave.webmvc;
 
+import brave.CurrentSpanCustomizer;
+import brave.SpanCustomizer;
 import brave.Tracing;
 import brave.context.log4j2.ThreadContextScopeDecorator;
 import brave.http.HttpTracing;
@@ -44,7 +46,7 @@ public class TracingConfiguration extends WebMvcConfigurerAdapter {
     return AsyncReporter.create(sender());
   }
 
-  /** Controls aspects of tracing such as the name that shows up in the UI */
+  /** Controls aspects of tracing such as the service name that shows up in the UI */
   @Bean Tracing tracing(@Value("${zipkin.service:brave-webmvc-example}") String serviceName) {
     return Tracing.newBuilder()
         .localServiceName(serviceName)
@@ -56,7 +58,12 @@ public class TracingConfiguration extends WebMvcConfigurerAdapter {
         .spanReporter(spanReporter()).build();
   }
 
-  // decides how to name and tag spans. By default they are named the same as the http method.
+  /** Allows someone to add tags to a span if a trace is in progress. */
+  @Bean SpanCustomizer spanCustomizer(Tracing tracing) {
+    return CurrentSpanCustomizer.create(tracing);
+  }
+
+  /** Decides how to name and tag spans. By default they are named the same as the http method. */
   @Bean HttpTracing httpTracing(Tracing tracing) {
     return HttpTracing.create(tracing);
   }


### PR DESCRIPTION
User code can use this to add tags to any existing span.

@GuangmingLuo I just used this in the backend app by adding a field `@Autowired SpanCustomizer spanCustomizer; ` and using it inside the business method.

@shiraji this tool is a nice one to see if propagation is working in process or not. While I don't know the solution to kotlin at the moment, using `@Autowired SpanCustomizer spanCustomizer; ` can show it works or not better than thread ID


FYI: I am not changing the code to use this because right now apps have no brave library dependency in their "business code" which is a good thing. We usually don't want people putting tracing code into their normal apps. A more realistic example would be using a servlet filter or similar, which is outside business code, to customize something that's not already customizable with `HttpTracing`